### PR TITLE
Update blobmsg_json.c

### DIFF
--- a/blobmsg_json.c
+++ b/blobmsg_json.c
@@ -15,6 +15,7 @@
  */
 #include "blobmsg.h"
 #include "blobmsg_json.h"
+#include <json/bits.h> //Or reference to is_error at __blobmsg_add_json() will give problems
 
 bool blobmsg_add_object(struct blob_buf *b, json_object *obj)
 {


### PR DESCRIPTION
When trying to compile on Ubuntu 14.04 got:

[ 48%] Building C object CMakeFiles/blobmsg_json.dir/blobmsg_json.c.o
/opt/git/libubox/blobmsg_json.c: In function ‘__blobmsg_add_json’:
/opt/git/libubox/blobmsg_json.c:78:2: error: implicit declaration of function ‘is_error’ [-Werror=implicit-function-declaration]
  if (is_error(obj))
  ^

adding #include json/bits.h solve the problem (You must have json-c sources on "/usr/include/json") for this to function.
