### PR TITLE
Update jshn.c

### DIFF
--- a/jshn.c
+++ b/jshn.c
@@ -19,6 +19,7 @@
         #include <json/json.h>
 #endif
 
+#include <json/bits.h> // or reference to is_error() at jshn_parse() will give problems
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
When trying to compile on Ubuntu 14.04 got:

[ 51%] Building C object CMakeFiles/jshn.dir/jshn.c.o
/opt/git/libubox/jshn.c: In function ‘jshn_parse’:
/opt/git/libubox/jshn.c:162:2: warning: implicit declaration of function ‘is_error’ [-Wimplicit-function-declaration]
  if (is_error(obj) || json_object_get_type(obj) != json_type_object) {
  ^

adding #include json/bits.h solve the problem (You must have json-c sources on "/usr/include/json") for this to function.
